### PR TITLE
Fix module installation

### DIFF
--- a/logs_monitoring.install
+++ b/logs_monitoring.install
@@ -11,19 +11,21 @@ use Drupal\user\RoleInterface;
 /**
  * Implements hook_install().
  */
-function logs_monitoring_install() {
+function logs_monitoring_install($is_syncing) {
   // Add permissions to anonymous and authenticated roles.
-  $permissions = [
-    'restful get logs_monitoring',
-  ];
-  $roles = Role::loadMultiple([
-    RoleInterface::ANONYMOUS_ID,
-    RoleInterface::AUTHENTICATED_ID
-  ]);
-  foreach ($roles as $role) {
-    foreach ($permissions as $permission) {
-      $role->grantPermission($permission);
+  if (!$is_syncing) {
+    $permissions = [
+      'restful get logs_monitoring',
+    ];
+    $roles = Role::loadMultiple([
+      RoleInterface::ANONYMOUS_ID,
+      RoleInterface::AUTHENTICATED_ID
+    ]);
+    foreach ($roles as $role) {
+      foreach ($permissions as $permission) {
+        $role->grantPermission($permission);
+      }
+      $role->save();
     }
-    $role->save();
   }
 }


### PR DESCRIPTION
When the module enable is delivered by configs on dev/prod environments during the install hook, Drupal does not yet see the dynamically created permission for Restful and aborts the installation with an error:
```
In Role.php line 207:
                                                                                                                          
  Adding non-existent permissions to a role is not allowed. The incorrect permissions are "restful get logs_monitoring".  
```
We only need to add these permissions when the module is enabled locally, then they will be exported to the config. We don't need to do this during synchronization.

See parent issue https://github.com/YMCA-GBW-ORG/ymcabrandywine/pull/1344
